### PR TITLE
00b0_survey_lso201***_circumcision: custom LSO circumcision extracts by type

### DIFF
--- a/src/00b0_survey_lso2014dhs-circumcision/orderly.yml
+++ b/src/00b0_survey_lso2014dhs-circumcision/orderly.yml
@@ -1,0 +1,25 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: LSO2014DHS circumcision dataset
+      filenames:
+        - artefacts/lso2014dhs_survey_circumcision.csv
+        - artefacts/lso2014dhs_survey_individuals.csv	
+
+displayname: Lesotho 2014 DHS circumcision data set
+
+description: |
+  Lesotho 2014 DHS included separate questions for whether respondent
+  was traditionally circumcised or medically circumcised.
+
+  Custom re-extract of this survey including both traditional and medical
+  circumcision age.
+
+
+packages:
+  - dplyr
+  - haven
+  - naomi.utils
+  - rdhs
+  - readr

--- a/src/00b0_survey_lso2014dhs-circumcision/script.R
+++ b/src/00b0_survey_lso2014dhs-circumcision/script.R
@@ -1,0 +1,78 @@
+
+mr <- readRDS(get_datasets("LSMR71FL.ZIP")[[1]])
+
+## variable                            description
+##    mv483                 Respondent circumcised
+##   mv483a                    Age at circumcision
+##   mv483b    NA - Who performed the circumcision
+##   mv483c NA - Place where circumcision was done
+##   sm805a   Respondent traditionally circumcised
+##   sm805b        Age at traditional circumcision
+##   sm805c       Respondent medically circumcised
+##   sm805d            Age at medical circumcision
+
+## Note: label for age <5 years different for mv483a and sm805d:
+
+## > attr(mr$mv483a, "labels")
+## during childhood <5 years                don't know                   missing 
+##                        95                        98                        99 
+
+## > attr(mr$sm805b, "labels")
+## during childhood (< 5 years)                   don't know 
+##                           96                           98 
+
+## > attr(mr$sm805d, "labels")
+## during childhood (< 5 years)                   don't know 
+##                           96                           98 
+
+
+dhs_individual_id <- function(cluster, household, line) {
+  sprintf("%4d%4d%3d", cluster, household, line)
+}
+
+#' Notes:
+#'
+#' * Recode circumcised <5 years as age 0
+#' * If circ_med_age <= circ_trad_age, code circ_where = "medical"
+#' 
+
+circ <- mr %>%
+  mutate(across(c(starts_with("mv483"), starts_with("sm805")), zap_labels)) %>%
+  transmute(
+    iso3 = "LSO",
+    survey_id = "LSO2014DHS",
+    individual_id = dhs_individual_id(mv001, mv002, mv003),
+    circ_status = recode(mv483, `1` = 1L, `0` = 0L, .default = NA_integer_),
+    circ_method = case_when(sm805a == 1 & sm805c == 1 ~ "both",
+                            sm805a == 1 ~ "traditional",
+                            sm805c == 1 ~ "medical"),
+    circ_age = case_when(mv483a < 95 ~ mv483a,
+                         mv483a == 95 ~ 0L,
+                         mv483a >= 96 ~ NA_integer_),
+    circ_trad_age = case_when(sm805b < 96 ~ sm805b,
+                              sm805b == 96 ~ 0L,
+                              sm805b >= 97 ~ NA_integer_),
+    circ_med_age = case_when(sm805d < 96 ~ sm805d,
+                             sm805d == 96 ~ 0L,
+                             sm805d >= 97 ~ NA_integer_)
+  )
+
+    
+circ <- circ %>%
+  mutate(
+    circ_where = case_when(circ_method == "both" & circ_med_age <= circ_trad_age ~ "medical",
+                           circ_method == "both" ~ "traditional",
+                           TRUE ~ circ_method)
+  )
+
+dir.create("artefacts")
+write_csv(circ, "artefacts/lso2014dhs_survey_circumcision.csv", na = "")
+
+
+#' ## Create survey_individuals dataset
+surveys <- create_surveys_dhs("LSO", "DHS")
+surveys <- filter(surveys, SurveyYear == 2014)
+dat <- naomi.utils::create_individual_hiv_dhs(surveys)
+ind <- naomi.utils::create_survey_individuals_dhs(dat)
+
+write_csv(ind, "artefacts/lso2014dhs_survey_individuals.csv", na = "")

--- a/src/00b0_survey_lso2017phia-circumcision/#script.R#
+++ b/src/00b0_survey_lso2017phia-circumcision/#script.R#
@@ -1,0 +1,115 @@
+
+#' ## Circumcision variables in LePHIA 2016-17
+#' 
+#' mcstatus:
+#'  Some men are uncomfortable talking about circumcision but it is important for us to have this information.   Some men are circumcised. Are you circumcised?
+#'  *  1 - YES
+#'  *  2 - NO
+#'  * -8 - DON'T KNOW
+#'  * -9 - REFUSED"
+#'
+#' mcmeth:
+#'   If so, were you medically circumcised, traditionally circumcised, or both?
+#'   *  1 - MEDICAL
+#'   *  2 - TRADITIONAL
+#'   *  3 - BOTH
+#'   *  -8 - DON'T KNOW
+#'   *  -9 - REFUSED
+#'
+#' mcparcom:
+#'   Are you completely or partially circumcised?
+#'   *  1 - COMPLETELY
+#'   *  2 - PARTIALLY
+#'   *  -8 - DON'T KNOW
+#'   *  -9 - REFUSED
+#' 
+#' mcage:
+#'   How old were you when you were medically circumcised? Please give your best guess. (top coded at 35)
+#'
+#' mcagedk:
+#'   Please provide the reason this previous question was left blank: HOW OLD WERE YOU WHEN YOU WERE MEDICALLY CIRCUMCISED?
+#'   * -8 - DON'T KNOW
+#'   * -9 - REFUSED
+#'
+#' mcagetrd:
+#'   How old were you when you were traditionally circumcised? Please give your best guess. (bottom coded at 13 and top coded at 25)
+#'
+#' mcagetrd:
+#'   Please provide the reason this previous question was left blank: HOW OLD WERE YOU WHEN YOU WERE TRADITIONALLY CIRCUMCISED?
+#'   * -8 - DON'T KNOW
+#'   * -9 - REFUSED
+#' 
+#' mcwho:
+#'  Who did the circumcision?
+#'  *  1 - DOCTOR, CLINICAL OFFICER, OR NURSE
+#'  *  2 - TRADITIONAL PRACTITIONER/CIRCUMCISER/INITIATION SCHOOL PERSONNEL
+#'  *  3 - MIDWIFE
+#'  *  4 - RELIGIOUS LEADER
+#'  *  5 - FAMILY MEMBER/RELATIVE
+#'  * 96 - OTHER (SPECIFY)
+#'  * -8 - DON'T KNOW
+#'  * -9 - REFUSED
+
+
+#' Download LSO2017PHIA individual data set from Sharepoint
+
+sharepoint <- spud::sharepoint$new(Sys.getenv("SHAREPOINT_URL"))
+
+url <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA/datasets/LSO/datasets/203_LePHIA 2016-2017 Adult Interview Dataset (CSV).zip" %>%
+  URLencode()
+
+file <- sharepoint$download(url)
+tmpd <- tempfile()
+unzip(file, "lephia2016adultind.csv", exdir = tmpd)
+
+raw <- read_csv(file.path(tmpd, "lephia2016adultind.csv"), na = ".")
+
+circ <- raw %>%
+  filter(
+    indstatus == 1,   ## 1 = 'Eligible respondent'
+    gender == 1       ## 1 = Male
+  ) %>%
+  transmute(
+    iso3 = "LSO",
+    survey_id = "LSO2017PHIA",
+    individual_id = personid,
+    circ_status = recode(mcstatus, `1` = 1L, `2` = 0L, .default = NA_integer_),
+    circ_partial = recode(mcparcom, `1` = "complete", `2` = "partial", .default = NA_character_),
+    circ_method = recode(mcmeth, `1` = "medical", `2` = "traditional", `3` = "both", .default = NA_character_),
+    circ_who = mcwho %>%
+      recode(`1` = "medical",
+             `2` = "traditional",
+             `3` = "traditional",
+             `4` = "traditional",
+             `5` = "traditional",
+             `96` = "traditional",
+             .default = NA_character_),
+    circ_med_age = mcage,
+    circ_trad_age = mcagetrd
+  ) 
+
+circ %>%
+  filter(!is.na(circ_med_age),
+         !is.na(circ_trad_age)) %>%
+  count(circ_method)
+
+#' If circ_method = "both": code as first reported circumcision
+#' 
+#' * Code circ_age as minimum of circ_med_age and circ_trad_age
+#' * Code circ_where as which was first
+#' * Recode circ_who = "traditional" if it was traditional circumcision reported
+#'   before medical circumcision
+
+
+circ <- circ %>%
+  mutate(
+    circ_age = pmin(circ_trad_age, circ_med_age, na.rm = TRUE),
+    circ_where = case_when(!is.na(circ_med_age) & is.na(circ_trad_age) ~ "medical",
+                           circ_med_age <= circ_trad_age ~ "medical",
+                           !is.na(circ_trad_age) ~ "traditional"),
+    circ_who = if_else(!is.na(circ_trad_age) & !is.na(circ_med_age) &
+                         circ_trad_age < circ_med_age,
+                       "traditional", circ_who)
+  )
+
+write_csv(circ, "lso2017phia-circumcision.csv", na = "")

--- a/src/00b0_survey_lso2017phia-circumcision/orderly.yml
+++ b/src/00b0_survey_lso2017phia-circumcision/orderly.yml
@@ -1,0 +1,20 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: LSO2017PHIA circumcision dataset
+      filenames: artefacts/lso2017phia-circumcision.csv
+
+displayname: Lesotho 2017 PHIA circumcision data set
+
+description: |
+  Lesotho 2016-17 PHIA included separate questions for whether respondent
+  was traditionally circumcised or medically circumcised.
+
+  Custom re-extract of this survey including both traditional and medical
+  circumcision age.
+
+
+packages:
+  - dplyr
+  - readr

--- a/src/00b0_survey_lso2017phia-circumcision/script.R
+++ b/src/00b0_survey_lso2017phia-circumcision/script.R
@@ -1,0 +1,116 @@
+
+#' ## Circumcision variables in LePHIA 2016-17
+#' 
+#' mcstatus:
+#'  Some men are uncomfortable talking about circumcision but it is important for us to have this information.   Some men are circumcised. Are you circumcised?
+#'  *  1 - YES
+#'  *  2 - NO
+#'  * -8 - DON'T KNOW
+#'  * -9 - REFUSED"
+#'
+#' mcmeth:
+#'   If so, were you medically circumcised, traditionally circumcised, or both?
+#'   *  1 - MEDICAL
+#'   *  2 - TRADITIONAL
+#'   *  3 - BOTH
+#'   *  -8 - DON'T KNOW
+#'   *  -9 - REFUSED
+#'
+#' mcparcom:
+#'   Are you completely or partially circumcised?
+#'   *  1 - COMPLETELY
+#'   *  2 - PARTIALLY
+#'   *  -8 - DON'T KNOW
+#'   *  -9 - REFUSED
+#' 
+#' mcage:
+#'   How old were you when you were medically circumcised? Please give your best guess. (top coded at 35)
+#'
+#' mcagedk:
+#'   Please provide the reason this previous question was left blank: HOW OLD WERE YOU WHEN YOU WERE MEDICALLY CIRCUMCISED?
+#'   * -8 - DON'T KNOW
+#'   * -9 - REFUSED
+#'
+#' mcagetrd:
+#'   How old were you when you were traditionally circumcised? Please give your best guess. (bottom coded at 13 and top coded at 25)
+#'
+#' mcagetrd:
+#'   Please provide the reason this previous question was left blank: HOW OLD WERE YOU WHEN YOU WERE TRADITIONALLY CIRCUMCISED?
+#'   * -8 - DON'T KNOW
+#'   * -9 - REFUSED
+#' 
+#' mcwho:
+#'  Who did the circumcision?
+#'  *  1 - DOCTOR, CLINICAL OFFICER, OR NURSE
+#'  *  2 - TRADITIONAL PRACTITIONER/CIRCUMCISER/INITIATION SCHOOL PERSONNEL
+#'  *  3 - MIDWIFE
+#'  *  4 - RELIGIOUS LEADER
+#'  *  5 - FAMILY MEMBER/RELATIVE
+#'  * 96 - OTHER (SPECIFY)
+#'  * -8 - DON'T KNOW
+#'  * -9 - REFUSED
+
+
+#' Download LSO2017PHIA individual data set from Sharepoint
+
+sharepoint <- spud::sharepoint$new(Sys.getenv("SHAREPOINT_URL"))
+
+url <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA/datasets/LSO/datasets/203_LePHIA 2016-2017 Adult Interview Dataset (CSV).zip" %>%
+  URLencode()
+
+file <- sharepoint$download(url)
+tmpd <- tempfile()
+unzip(file, "lephia2016adultind.csv", exdir = tmpd)
+
+raw <- read_csv(file.path(tmpd, "lephia2016adultind.csv"), na = ".")
+
+circ <- raw %>%
+  filter(
+    indstatus == 1,   ## 1 = 'Eligible respondent'
+    gender == 1       ## 1 = Male
+  ) %>%
+  transmute(
+    iso3 = "LSO",
+    survey_id = "LSO2017PHIA",
+    individual_id = personid,
+    circ_status = recode(mcstatus, `1` = 1L, `2` = 0L, .default = NA_integer_),
+    circ_partial = recode(mcparcom, `1` = "complete", `2` = "partial", .default = NA_character_),
+    circ_method = recode(mcmeth, `1` = "medical", `2` = "traditional", `3` = "both", .default = NA_character_),
+    circ_who = mcwho %>%
+      recode(`1` = "medical",
+             `2` = "traditional",
+             `3` = "traditional",
+             `4` = "traditional",
+             `5` = "traditional",
+             `96` = "traditional",
+             .default = NA_character_),
+    circ_med_age = mcage,
+    circ_trad_age = mcagetrd
+  ) 
+
+circ %>%
+  filter(!is.na(circ_med_age),
+         !is.na(circ_trad_age)) %>%
+  count(circ_method)
+
+#' If circ_method = "both": code as first reported circumcision
+#' 
+#' * Code circ_age as minimum of circ_med_age and circ_trad_age
+#' * Code circ_where as which was first
+#' * Recode circ_who = "traditional" if it was traditional circumcision reported
+#'   before medical circumcision
+
+
+circ <- circ %>%
+  mutate(
+    circ_age = pmin(circ_trad_age, circ_med_age, na.rm = TRUE),
+    circ_where = case_when(!is.na(circ_med_age) & is.na(circ_trad_age) ~ "medical",
+                           circ_med_age <= circ_trad_age ~ "medical",
+                           !is.na(circ_trad_age) ~ "traditional"),
+    circ_who = if_else(!is.na(circ_trad_age) & !is.na(circ_med_age) &
+                         circ_trad_age < circ_med_age,
+                       "traditional", circ_who)
+  )
+
+dir.create("artefacts")
+write_csv(circ, "artefacts/lso2017phia-circumcision.csv", na = "")

--- a/src/00b1_survey_cluster-individuals-circ_dhs-phia-ais/orderly.yml
+++ b/src/00b1_survey_cluster-individuals-circ_dhs-phia-ais/orderly.yml
@@ -188,7 +188,7 @@ depends:
     use:
       depends/lso2017phia_survey_clusters.csv: lso2017phia_survey_clusters.csv
       depends/lso2017phia_survey_individuals.csv: lso2017phia_survey_individuals.csv
-      depends/lso2017phia_survey_circumcision.csv: lso2017phia_survey_circumcision.csv
+      ## depends/lso2017phia_survey_circumcision.csv: lso2017phia_survey_circumcision.csv
   mwi_survey_phia:
     id: latest
     # id: latest(parameter:version == "2021")
@@ -245,4 +245,16 @@ depends:
       depends/zwe2016phia_survey_clusters.csv: zwe2016phia_survey_clusters.csv
       depends/zwe2016phia_survey_individuals.csv: zwe2016phia_survey_individuals.csv
       depends/zwe2016phia_survey_circumcision.csv: zwe2016phia_survey_circumcision.csv
-  
+
+
+  ## Recoded LSO circumcision: data sets include separate medical and traditional circ age
+  00b0_survey_lso2014dhs-circumcision:
+    id: latest
+    use:
+      depends/lso2014dhs_survey_circumcision.csv: artefacts/lso2014dhs_survey_circumcision.csv
+      depends/lso2014dhs_survey_individuals.csv: artefacts/lso2014dhs_survey_individuals.csv
+  00b0_survey_lso2017phia-circumcision:
+    id: latest
+    use:
+      depends/lso2017phia_survey_circumcision.csv: artefacts/lso2017phia-circumcision.csv
+    

--- a/src/00b1_survey_cluster-individuals-circ_dhs-phia-ais/script.R
+++ b/src/00b1_survey_cluster-individuals-circ_dhs-phia-ais/script.R
@@ -148,6 +148,15 @@ dhs_individuals <- dhs_individuals %>%
       filter(survey_id %in% dhs_individuals$survey_id))
   )
 
+#' Add LSO2014DHS -- custom extract
+lso2014dhs_individuals <- read_csv("depends/lso2014dhs_survey_individuals.csv")
+
+stopifnot(!lso2014dhs_individuals$survey_id %in% dhs_individuals$survey_id)
+
+dhs_individuals <- dhs_individuals %>%
+  bind_rows(lso2014dhs_individuals)
+
+
 # individual_id has been coded differently than in circumcision dataset
 
 dhs_individual_id <- function(cluster, household, line) {
@@ -201,9 +210,28 @@ dhs_circumcision <- as.list(dhs_circumcision) %>%
     survey_id != "CIV2005AIS"
   )
 
+#' Add LSO2014DHS survey (manual extract)
+
+lso2014dhs_circumcision <- read_csv("depends/lso2014dhs_survey_circumcision.csv") %>%
+  mutate(
+    individual_id = sprintf("%11s", individual_id)
+  )
+
+stopifnot(!lso2014dhs_circumcision$survey_id %in% dhs_circumcision$survey_id)
+
+dhs_circumcision <- dhs_circumcision %>%
+  bind_rows(lso2014dhs_circumcision)
+  
+
 phia_paths <- paste0("depends/", iso3_phia, phia_years, "phia_survey_circumcision.csv")
 phia_circumcision <- lapply(phia_paths, read_csv)
+
 names(phia_circumcision) <- toupper(iso3_phia)
+
+#' To match other PHIA surveys
+phia_circumcision$LSO <- phia_circumcision$LSO %>%
+  rename(circumcised = circ_status)
+
 phia_circumcision <- phia_circumcision %>% 
   Map(mutate, ., iso3 = toupper(names(.))) %>%
   bind_rows() %>%


### PR DESCRIPTION
This PR updates the LSO2014DHS and LSO2017PHIA surveys which had custom circumcision questions for allowing both traditional and medical circumcisions.

The LSO2014DHS is added and the circumcision variables for the LSO2017PHIA have been re-extracted and replaced in the task `00b1_survey_cluster-individuals-circ_dhs-phia-ais/orderly.yml`

Additional fields are added to the `survey_circumcision` data set:
  * `circ_method`: `"medical"`, `"traditional"`, `"both"`
  * `circ_trad_age`: age at traditional circumcision
  * `circ_med_age`: age at medical circumcision

`circ_status` and `circ_age` are coded as the first circumcision event. If both medical and traditional circumcision were reported in the same year, it is recorded as medical.

The PHIA survey also has a variable recording self-reported _partial_ or _complete_ circumcision which is extracted.